### PR TITLE
Always add -fPIC to Fortran compiler flags

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -42,7 +42,7 @@ default: all
 	$(CC) $(CPPFLAGS) $(CFLAGS_add) $(CFLAGS) -c $< -o $@
 
 %.f.o: %.f
-	$(FC) $(FFLAGS) -c $< -o $@
+	$(FC) $(FFLAGS) $(FFLAGS_add) -c $< -o $@
 
 %.S.o: %.S
 	$(CC) $(SFLAGS) $(filter -m% -B% -I% -D%,$(CFLAGS_add)) -c $< -o $@
@@ -68,25 +68,25 @@ endif
 #keep these if statements these separate
 ifeq ($(OS), WINNT)
 CFLAGS_add+=-nodefaultlibs
-FFLAGS+=-nodefaultlibs
+FFLAGS_add+=-nodefaultlibs
 endif
 
 ifeq ($(OS), Linux)
 SHLIB_EXT = so
 CFLAGS_add+=-fPIC
-FFLAGS+=-fPIC
+FFLAGS_add+=-fPIC
 endif
 
 ifeq ($(OS), FreeBSD)
 SHLIB_EXT = so
 CFLAGS_add+=-fPIC
-FFLAGS+=-fPIC
+FFLAGS_add+=-fPIC
 endif
 
 ifeq ($(OS), Darwin)
 SHLIB_EXT = dylib
 CFLAGS_add+=-fPIC
-FFLAGS+=-fPIC
+FFLAGS_add+=-fPIC
 endif
 
 ifeq ($(OS), WINNT)


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/openlibm/issues/31. Needed in particular to build distribution packages which set their own FFLAGS.

I don't understand why the current `FFLAGS+=-fPIC` had no effect, but since the file already does this with CFLAGS, there must be a reason. The result works.
