### PR TITLE
Use `override` with `-fPIC` option so it is ALWAYS included

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -74,19 +74,19 @@ endif
 ifeq ($(OS), Linux)
 SHLIB_EXT = so
 CFLAGS_add+=-fPIC
-FFLAGS+=-fPIC
+override FFLAGS+=-fPIC
 endif
 
 ifeq ($(OS), FreeBSD)
 SHLIB_EXT = so
 CFLAGS_add+=-fPIC
-FFLAGS+=-fPIC
+override FFLAGS+=-fPIC
 endif
 
 ifeq ($(OS), Darwin)
 SHLIB_EXT = dylib
 CFLAGS_add+=-fPIC
-FFLAGS+=-fPIC
+override FFLAGS+=-fPIC
 endif
 
 ifeq ($(OS), WINNT)


### PR DESCRIPTION
I'm a little dissatisfied with the `CFLAGS_add` solutions in `Make.inc`.  `make` gives us two behaviors for assigning variables: those that the user can overturn easily (`=`, `+=`, `:=`) and those that they cannot (prefixed with `override`).  By creating a nonstandard variable name, we create a second tier of overridable values in the Makefile.

I think it would be more straightforward for everyone involved if we just separate the Makefile into default `{C,F}FLAG` values, and those that cannot be overridden, added onto the `{C,F}FLAG` values via `override`.

Viral, if you agree, I'll update this PR with the changes.
