### PR TITLE
Always use C99 mode with gcc

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -37,7 +37,7 @@ endif
 
 ifeq ($(USEGCC),1)
 CC = gcc
-override CFLAGS_add += -fno-gnu89-inline
+override CFLAGS_add += -fno-gnu89-inline -std=c99
 endif
 
 ARCH := $(shell $(CC) -dumpmachine | sed "s/\([^-]*\).*$$/\1/")


### PR DESCRIPTION
I've found this issue when building my RPM package.
