### PR TITLE
Do not add PREFIX to LIBDIR

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -6,7 +6,7 @@ VERSION_SPLIT = $(subst ., , $(VERSION))
 $(warning vs: $(VERSION_SPLIT))
 PREFIX = /usr/local
 DESTDIR =
-LIBDIR = lib/
+LIBDIR = $(PREFIX)/lib/
 
 FC = gfortran
 # CFLAGS_add and FFLAGS_add are flags that we always want to include

--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,10 @@ libopenspecfun.$(SHLIB_EXT): $(OBJS)
 	ln -s libopenspecfun.$(SHLIB_EXT).$(VERSION) libopenspecfun.$(SHLIB_EXT)
 
 install: all
-	for subdir in $(LIBDIR) include; do \
-		mkdir -p $(DESTDIR)$(PREFIX)/$$subdir; \
-	done
+	mkdir -p $(DESTDIR)/$(LIBDIR)
+	mkdir -p $(DESTDIR)$(PREFIX)/include
 
-	cp -a libopenspecfun.$(SHLIB_EXT)* libopenspecfun.a $(DESTDIR)$(PREFIX)/$(LIBDIR)
+	cp -a libopenspecfun.$(SHLIB_EXT)* libopenspecfun.a $(DESTDIR)/$(LIBDIR)/
 	cp -a Faddeeva/Faddeeva.h $(DESTDIR)$(PREFIX)/include/
 
 clean:


### PR DESCRIPTION
LIBDIR is supposed to be an absolute path, already including PREFIX.
