### PR TITLE
Stop including math_private.h from openlibm

### DIFF
--- a/Faddeeva/Faddeeva.cc
+++ b/Faddeeva/Faddeeva.cc
@@ -249,7 +249,7 @@ typedef double complex cmplx;
 
 #  ifdef USE_OPENLIBM
 #  ifndef CMPLX
-#    include "math_private.h"
+#    include "openlibm.h"
 #    define CMPLX(a,b) cpack(a,b)
 #  endif
 #  endif


### PR DESCRIPTION
Now the required declarations about complex numbers
are in openlibm.h.

https://github.com/JuliaLang/julia/pull/6238
