### PR TITLE
Install libopenspecfun.dll to bindir

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -5,6 +5,7 @@ VERSION = 0.1.0
 VERSION_SPLIT = $(subst ., , $(VERSION))
 DESTDIR =
 prefix = /usr/local
+bindir = $(prefix)/bin
 libdir = $(prefix)/lib
 includedir = $(prefix)/include
 
@@ -82,12 +83,15 @@ ifneq (,$(findstring MINGW,$(OS)))
 override OS=WINNT
 endif
 
-#keep these if statements these separate
+#keep these if statements separate
 ifeq ($(OS), WINNT)
 SHLIB_EXT = dll
 SONAME_FLAG = -soname
 override CFLAGS_add += -nodefaultlibs
 override FFLAGS_add += -nodefaultlibs
+shlibdir = bindir
+else
+shlibdir = libdir
 endif
 
 ifeq ($(OS), Linux)

--- a/Makefile
+++ b/Makefile
@@ -25,16 +25,21 @@ all: libopenspecfun.a libopenspecfun.$(SHLIB_EXT)
 libopenspecfun.a: $(OBJS)
 	$(AR) -rcs libopenspecfun.a $(OBJS)
 libopenspecfun.$(SHLIB_EXT): $(OBJS)
+ifeq ($(OS),WINNT)
+	$(FC) -shared $(OBJS) $(LDFLAGS) -Wl,$(SONAME_FLAG),libopenspecfun.$(SHLIB_EXT) -o libopenspecfun.$(SHLIB_EXT)
+else
 	$(FC) -shared $(OBJS) $(LDFLAGS) -Wl,$(SONAME_FLAG),libopenspecfun.$(SHLIB_EXT).$(VERSION) -o libopenspecfun.$(SHLIB_EXT).$(VERSION)
 	ln -s libopenspecfun.$(SHLIB_EXT).$(VERSION) libopenspecfun.$(SHLIB_EXT).$(word 1,$(VERSION_SPLIT)).$(word 2,$(VERSION_SPLIT))
 	ln -s libopenspecfun.$(SHLIB_EXT).$(VERSION) libopenspecfun.$(SHLIB_EXT).$(word 1,$(VERSION_SPLIT))
 	ln -s libopenspecfun.$(SHLIB_EXT).$(VERSION) libopenspecfun.$(SHLIB_EXT)
+endif
 
 install: all
+	mkdir -p $(DESTDIR)$(shlibdir)
 	mkdir -p $(DESTDIR)$(libdir)
 	mkdir -p $(DESTDIR)$(includedir)
-
-	cp -a libopenspecfun.$(SHLIB_EXT)* libopenspecfun.a $(DESTDIR)$(libdir)/
+	cp -a libopenspecfun.$(SHLIB_EXT)* $(DESTDIR)$(shlibdir)/
+	cp -a libopenspecfun.a $(DESTDIR)$(libdir)/
 	cp -a Faddeeva/Faddeeva.h $(DESTDIR)$(includedir)
 
 clean:


### PR DESCRIPTION
Also skip dll versioning on Windows

This is an alternative to https://github.com/JuliaLang/julia/pull/6459 - if this gets merged here, I'll modify that PR in Julia to stop special-casing the openspecfun install rule for Windows. (And include the submodule bump.)
