### PR TITLE
Introduce SONAME_VERSION

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -2,6 +2,9 @@
 
 OS := $(shell uname)
 VERSION = 0.3.0
+# This SONAME_VERSION is independent of the major version decimal.
+# It should only be incremented when backwards-incompatible changes are made
+SONAME_VERSION = 0
 VERSION_SPLIT = $(subst ., , $(VERSION))
 DESTDIR =
 prefix = /usr/local

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ libopenspecfun.$(SHLIB_EXT): $(OBJS)
 ifeq ($(OS),WINNT)
 	$(FC) -shared $(OBJS) $(LDFLAGS) -Wl,$(SONAME_FLAG),libopenspecfun.$(SHLIB_EXT) -o libopenspecfun.$(SHLIB_EXT)
 else
-	$(FC) -shared $(OBJS) $(LDFLAGS) -Wl,$(SONAME_FLAG),libopenspecfun.$(SHLIB_EXT).$(VERSION) -o libopenspecfun.$(SHLIB_EXT).$(VERSION)
+	$(FC) -shared $(OBJS) $(LDFLAGS) -Wl,$(SONAME_FLAG),libopenspecfun.$(SHLIB_EXT).$(SONAME_VERSION) -o libopenspecfun.$(SHLIB_EXT).$(VERSION)
 	ln -s libopenspecfun.$(SHLIB_EXT).$(VERSION) libopenspecfun.$(SHLIB_EXT).$(word 1,$(VERSION_SPLIT)).$(word 2,$(VERSION_SPLIT))
 	ln -s libopenspecfun.$(SHLIB_EXT).$(VERSION) libopenspecfun.$(SHLIB_EXT).$(word 1,$(VERSION_SPLIT))
 	ln -s libopenspecfun.$(SHLIB_EXT).$(VERSION) libopenspecfun.$(SHLIB_EXT)


### PR DESCRIPTION
use that instead of VERSION for setting the SONAME on non-windows versions

@sebastien-villemot @nalimilan does this satisfy proper `SONAME` procedures?
