### PR TITLE
remove DLLEXPORT from rem_pio2 functions

### DIFF
--- a/rem_pio2/e_rem_pio2.c
+++ b/rem_pio2/e_rem_pio2.c
@@ -52,7 +52,7 @@ pio2_3t =  8.47842766036889956997e-32; /* 0x397B839A, 0x252049C1 */
 extern
 #endif
 //__inline int
-DLLEXPORT int 
+int 
 __ieee754_rem_pio2(double x, double *y)
 {
 	double z,w,t,r,fn;

--- a/rem_pio2/e_rem_pio2f.c
+++ b/rem_pio2/e_rem_pio2f.c
@@ -44,7 +44,7 @@ pio2_1t =  1.58932547735281966916e-08; /* 0x3E5110b4, 0x611A6263 */
 extern
 #endif
 //__inline int
-DLLEXPORT int
+int
 __ieee754_rem_pio2f(float x, double *y)
 {
 	double w,r,fn;

--- a/rem_pio2/k_rem_pio2.c
+++ b/rem_pio2/k_rem_pio2.c
@@ -290,7 +290,7 @@ one    = 1.0,
 two24   =  1.67772160000000000000e+07, /* 0x41700000, 0x00000000 */
 twon24  =  5.96046447753906250000e-08; /* 0x3E700000, 0x00000000 */
 
-DLLEXPORT int
+int
 __kernel_rem_pio2(double *x, double *y, int e0, int nx, int prec)
 {
 	int32_t jz,jx,jv,jp,jk,carry,n,iq[20],i,j,k,m,q0,ih;


### PR DESCRIPTION
When some functions in libopenspecfun.dll have `DLLEXPORT` and others don't, only the `DLLEXPORT` ones get exported on Windows. When none of the functions have `DLLEXPORT` on them, everything gets exported. This is easier than making amos export its functions from Fortran.

ref https://github.com/JuliaLang/julia/pull/7547#issuecomment-48662073
