### PR TITLE
Separate SOVERSION from release version

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1,8 +1,13 @@
 # -*- mode: makefile-gmake -*-
 
 OS := $(shell uname)
+
+# Do not forget to bump SOMINOR when changing VERSION,
+# and SOMAJOR when changing API
 VERSION = 0.4
-VERSION_SPLIT = $(subst ., , $(VERSION))
+SOMAJOR = 1
+SOMINOR = 0
+
 DESTDIR =
 prefix = /usr/local
 bindir = $(prefix)/bin

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,9 @@ libopenspecfun.$(SHLIB_EXT): $(OBJS)
 ifeq ($(OS),WINNT)
 	$(FC) -shared $(OBJS) $(LDFLAGS) -Wl,$(SONAME_FLAG),libopenspecfun.$(SHLIB_EXT) -o libopenspecfun.$(SHLIB_EXT)
 else
-	$(FC) -shared $(OBJS) $(LDFLAGS) -Wl,$(SONAME_FLAG),libopenspecfun.$(SHLIB_EXT).$(word 1,$(VERSION_SPLIT)) -o libopenspecfun.$(SHLIB_EXT).$(VERSION)
-	ln -sf libopenspecfun.$(SHLIB_EXT).$(VERSION) libopenspecfun.$(SHLIB_EXT).$(word 1,$(VERSION_SPLIT))
-	ln -sf libopenspecfun.$(SHLIB_EXT).$(VERSION) libopenspecfun.$(SHLIB_EXT)
+	$(FC) -shared $(OBJS) $(LDFLAGS) -Wl,$(SONAME_FLAG),libopenspecfun.$(SHLIB_EXT).$(SOMAJOR) -o libopenspecfun.$(SHLIB_EXT).$(SOMAJOR).$(SOMINOR)
+	ln -sf libopenspecfun.$(SHLIB_EXT).$(SOMAJOR).$(SOMINOR) libopenspecfun.$(SHLIB_EXT).$(SOMAJOR)
+	ln -sf libopenspecfun.$(SHLIB_EXT).$(SOMAJOR).$(SOMINOR) libopenspecfun.$(SHLIB_EXT)
 endif
 
 install: all


### PR DESCRIPTION
Needed to break API in 0.4 without calling it 1.0.

Cf. JuliaLang/julia#5365 and https://github.com/JuliaLang/openlibm/pull/65.
