### PR TITLE
Build on GNU/kfreeBSD and GNU/Hurd

### DIFF
--- a/rem_pio2/fpmath.h
+++ b/rem_pio2/fpmath.h
@@ -43,8 +43,8 @@
 #  define _FPMATH_LITTLE_ENDIAN __ORDER_LITTLE_ENDIAN__
 #  define _FPMATH_BYTE_ORDER    __BYTE_ORDER__
 // If not defined by the preprocessor, let us try to do it ourselves.
-// Linux
-#elif defined(__linux)
+// GNU C Library (GLIBC) - Linux, GNU/kFreeBSD, GNU/Hurd, etc.
+#elif defined(__GLIBC__)
 #  include <features.h>
 #  include <endian.h>
 #  define _FPMATH_LITTLE_ENDIAN  __LITTLE_ENDIAN


### PR DESCRIPTION
Debian's GNU/kFreeBSD port consists of a GNU userland using the GNU C library on top of a FreeBSD kernel. Similarly, Debian's GNU/Hurd runs on top of the GNU Mach microkernel.