### PR TITLE
Fix portability issues

### DIFF
--- a/rem_pio2/cdefs-compat.h
+++ b/rem_pio2/cdefs-compat.h
@@ -1,25 +1,6 @@
 #ifndef _CDEFS_COMPAT_H_
 #define	_CDEFS_COMPAT_H_
 
-#if !defined(_WIN32) && !defined(__sun)
-#include "sys/cdefs.h"
-#else /* _WIN32 || __sun */
-
-#if defined(__cplusplus)
-#define	__BEGIN_DECLS	extern "C" {
-#define	__END_DECLS	}
-#else
-#define	__BEGIN_DECLS
-#define	__END_DECLS
-#endif
-
-#define _SYS_CDEFS_H_
-
-#endif /* _WIN32 || __sun */
-
-
-
-
 #ifdef __GNUC__
 #ifndef __strong_reference
 #ifdef __APPLE__

--- a/rem_pio2/e_rem_pio2.c
+++ b/rem_pio2/e_rem_pio2.c
@@ -58,7 +58,7 @@ __ieee754_rem_pio2(double x, double *y)
 	double z,w,t,r,fn;
 	double tx[3],ty[2];
 	int32_t e0,i,j,nx,n,ix,hx;
-	u_int32_t low;
+	uint32_t low;
 
 	GET_HIGH_WORD(hx,x);		/* high word of x */
 	ix = hx&0x7fffffff;
@@ -139,7 +139,7 @@ medium:
 	    r  = x-fn*pio2_1;
 	    w  = fn*pio2_1t;	/* 1st round good to 85 bit */
 	    {
-	        u_int32_t high;
+	        uint32_t high;
 	        j  = ix>>20;
 	        y[0] = r-w; 
 		GET_HIGH_WORD(high,y[0]);

--- a/rem_pio2/math_private.h
+++ b/rem_pio2/math_private.h
@@ -48,12 +48,12 @@ typedef union
   double value;
   struct
   {
-    u_int32_t msw;
-    u_int32_t lsw;
+    uint32_t msw;
+    uint32_t lsw;
   } parts;
   struct
   {
-    u_int64_t w;
+    uint64_t w;
   } xparts;
 } ieee_double_shape_type;
 
@@ -66,12 +66,12 @@ typedef union
   double value;
   struct
   {
-    u_int32_t lsw;
-    u_int32_t msw;
+    uint32_t lsw;
+    uint32_t msw;
   } parts;
   struct
   {
-    u_int64_t w;
+    uint64_t w;
   } xparts;
 } ieee_double_shape_type;
 
@@ -227,7 +227,7 @@ do {								\
 /*
  * Common routine to process the arguments to nan(), nanf(), and nanl().
  */
-void _scan_nan(u_int32_t *__words, int __num_words, const char *__s);
+void _scan_nan(uint32_t *__words, int __num_words, const char *__s);
  
 #ifdef __GNUCLIKE_ASM
 


### PR DESCRIPTION
sys/cdefs.h is an internal glibc header and should *never* be used
u_int_* is system dependent, the C99 standard is uint_*


fixes #34