### PR TITLE
Compile with Clang on FreeBSD

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -32,7 +32,7 @@ override LDFLAGS_add =
 USEGCC = 1
 USECLANG = 0
 
-ifeq ($(OS), Darwin)
+ifneq (,$(findstring $(OS),FreeBSD Darwin))
 USEGCC = 0
 USECLANG = 1
 endif


### PR DESCRIPTION
Clang is the default compiler on FreeBSD so we should build OpenSpecFun with it.